### PR TITLE
Add missing comma in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://www.ti.com/lit/pdf/slaae88
 
       -n, --no-script         Do not execute init/exit script.
 
-      -N  --no-connect        Do not send connect command to BSL.
+      -N, --no-connect        Do not send connect command to BSL.
 
       -l, --length            Length of CRC to calculate.
 

--- a/main.c
+++ b/main.c
@@ -148,7 +148,7 @@ static void usage(char* self)
 "\n"
 "  -n, --no-script         Do not execute init/exit script.\n"
 "\n"
-"  -N  --no-connect        Do not send connect command to BSL.\n"
+"  -N, --no-connect        Do not send connect command to BSL.\n"
 "\n"
 "  -l, --length            Length of CRC to calculate.\n"
 "\n"


### PR DESCRIPTION
All other CLI flags also follow this same pattern.